### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,7 @@
   "provides" : {
     "Slang::Kazu" : "lib/Slang/Kazu.pm6"
   },
-  "license" : "https://www.gnu.org/licenses/gpl-3.0.txt",
+  "license" : "GPL-3.0",
   "test-depends" : [
     "Test::META"
   ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license